### PR TITLE
feat: 支持搜索的版本号排序能力

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -174,7 +174,7 @@ func (c *Cli) initiate() {
 		Aliases: []string{"L"},
 		GroupID: GroupID,
 		Short:   "Shows installed versions for an app.",
-		Long:    "Example: vm l go.",
+		Long:    "Example: vm L go.",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 {
 				cmd.Help()

--- a/pkgs/installer/search.go
+++ b/pkgs/installer/search.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gvcgo/goutils/pkgs/gtea/gprint"
 	"github.com/gvcgo/goutils/pkgs/gtea/gtable"
+	"github.com/gvcgo/version-manager/pkgs/utils"
 	"github.com/gvcgo/version-manager/pkgs/versions"
 )
 
@@ -41,6 +42,9 @@ func (s *Searcher) Search(appName string) {
 		gprint.PrintWarning("No versions found!")
 		return
 	}
+
+	// Sort versions.
+	utils.SortVersions(vl)
 
 	columns := []gtable.Column{
 		{Title: fmt.Sprintf("%v available versions", appName), Width: 150},

--- a/pkgs/utils/sort.go
+++ b/pkgs/utils/sort.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"errors"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Version represents a version number.
+type Version struct {
+	Major, Minor, Patch int
+}
+
+// ParseVersion parses a version string into a Version struct.
+func ParseVersion(version string) (Version, error) {
+	parts := strings.Split(version, ".")
+	if len(parts) != 3 {
+		return Version{}, errors.New("invalid version format")
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return Version{}, err
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return Version{}, err
+	}
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return Version{}, err
+	}
+	return Version{Major: major, Minor: minor, Patch: patch}, nil
+}
+
+// SortVersions sorts a slice of version strings in descending order.
+func SortVersions(versions []string) {
+	sort.Slice(versions, func(i, j int) bool {
+		v1, err := ParseVersion(versions[i])
+		if err != nil {
+			return false
+		}
+		v2, err := ParseVersion(versions[j])
+		if err != nil {
+			return false
+		}
+		if v1.Major != v2.Major {
+			return v1.Major > v2.Major
+		}
+		if v1.Minor != v2.Minor {
+			return v1.Minor > v2.Minor
+		}
+		return v1.Patch > v2.Patch
+	})
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,7 +45,6 @@ main() {
     local os_arch="$(uname -m)"
     local version="v0.1.1"
     local download_url="https://gvc.1710717.xyz/proxy/https://github.com/gvcgo/version-manager/releases/download/"
-    
     local osType="linux"
     if [ "$os_type" = "Darwin" ]; then
         osType="darwin"
@@ -68,8 +67,8 @@ main() {
 
     curl -o "$filename" "$url"
 
-    ehco "Installing..."
-    
+    echo "Installing..."
+
     if [ -s "./$filename" ]; then
         unzip "./$filename"
         chmod +x "./vm"


### PR DESCRIPTION
## 首次提交

趁项目刚发布，提交一个小小的修复。

PS：看到项目的前言，我啪一下就点进来了，体验之后，感觉就是我一直苦苦追寻的版本管理工具。已安排了go和node的版本，体验很好。已卸载gvm,nvm,vfox，是的，我也挺爱折腾的。

体验下来感觉还有一些值得斟酌的，比如一级参数的语义，以往用习惯gvm，nvm了，他们是 list 展示本地已安装的，listall展示远端所有的，vm则是local为本地，search为列出所有。还有就是没有给单独的install参数，有时候吧，可能是先install，暂时还不打算use，等用的时候再use。当然，这些都是我以往的使用习惯。

## 第二次提交

随着对这个项目的把玩，还发现了一些小的值得优化的地方，这次新增了搜索的版本号排序的能力。

以下是前后对比图：

**before：**

![image](https://github.com/gvcgo/version-manager/assets/33259379/9d2d1573-39dd-448a-b5e1-73d0db9838fd)


**after：**

![image](https://github.com/gvcgo/version-manager/assets/33259379/1d005f46-fb16-4093-9afd-dcb05ba547d2)

## 第三次提交

修复了一个文案上的小错误。