### PR TITLE
feat: 增加自动生成release与binary的action

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,42 @@
+# Configuration for Release Drafter: https://github.com/toolmantim/release-drafter
+name-template: 'v$NEXT_PATCH_VERSION 🌈'
+tag-template: 'v$NEXT_PATCH_VERSION'
+version-template: $MAJOR.$MINOR.$PATCH
+# Emoji reference: https://gitmoji.carloscuesta.me/
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+      - 'kind/feature'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+      - 'regression'
+      - 'kind/bug'
+  - title: 📝 Documentation updates
+    labels:
+      - 'doc'
+      - 'documentation'
+      - 'kind/doc'
+  - title: 👻 Maintenance
+    labels:
+      - chore
+      - dependencies
+      - 'kind/chore'
+      - 'kind/dep'
+  - title: 🚦 Tests
+    labels:
+      - test
+      - tests
+exclude-labels:
+  - reverted
+  - no-changelog
+  - skip-changelog
+  - invalid
+change-template: '* $TITLE (#$NUMBER) @$AUTHOR'
+template: |
+  ## What’s Changed
+  $CHANGES

--- a/.github/workflows/go-binary-release.yml
+++ b/.github/workflows/go-binary-release.yml
@@ -1,0 +1,27 @@
+name: build
+
+on:
+  release:
+    types: [created,published] # 表示在创建新的 Release 时触发
+
+jobs:
+  build-go-binary:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, windows, darwin] # 需要打包的系统
+        goarch: [amd64, arm64] # 需要打包的架构
+    steps:
+      - uses: actions/checkout@v3
+      - uses: wangyoucao577/go-release-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }} # 一个默认的变量，用来实现往 Release 中添加文件
+          goos: ${{ matrix.goos }}
+          goarch: ${{ matrix.goarch }}
+          retry: 10
+          overwrite: true
+          goversion: 1.22.0 # 可以指定编译使用的 Golang 版本
+          binary_name: "vm" # 可以指定二进制文件的名称
+          compress_assets: zip # 可以指定压缩的方式，支持 zip 和 tar.gz
+          project_path: "cmd/vm" # 指定项目路径
+          asset_name: vm_${{ matrix.goos }}_${{ matrix.goarch }}

--- a/.github/workflows/go-binary-release.yml
+++ b/.github/workflows/go-binary-release.yml
@@ -24,4 +24,4 @@ jobs:
           binary_name: "vm" # 可以指定二进制文件的名称
           compress_assets: zip # 可以指定压缩的方式，支持 zip 和 tar.gz
           project_path: "cmd/vm" # 指定项目路径
-          asset_name: vm_${{ matrix.goos }}_${{ matrix.goarch }}
+          asset_name: vm_${{ matrix.goos }}-${{ matrix.goarch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - main
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  # pull_request_target:
+  #   types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write  # for release-drafter/release-drafter to create a github release
+      pull-requests: write  # for release-drafter/release-drafter to add label to PR
+    runs-on: ubuntu-latest
+    steps:
+      # (Optional) GitHub Enterprise requires GHE_HOST variable set
+      #- name: Set GHE_HOST
+      #  run: |
+      #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
+
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        # with:
+        #   config-name: my-config.yml
+        #   disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
昨天也顺带调试了一下自动生成release与binary的action，以后只需要维护pr，然后发布release即可，之后会自动触发action构建二进制。这样以后就可以专注与编码，而不必再花精力维护release了。`为了不影响原来安装脚本，对应的二进制命名与原来的一致。`

效果如下：

![image](https://github.com/gvcgo/version-manager/assets/33259379/17356c03-9720-4f3e-84b3-728c59bd239d)

TODO: 我注意到，此action打出来的二进制要比原来的略大一丢丢，原来12M，现在17M，昨天也调试了upx的参数，但貌似Windows平台那块儿总会出错，又考虑到此二进制大小影响还好，故而放弃折腾。