### PR TITLE
fix: 指定 Command 二进制文件名，修复 completion 异常

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -53,6 +53,7 @@ type Cli struct {
 func New(gitTag, gitHash string) (c *Cli) {
 	c = &Cli{
 		rootCmd: &cobra.Command{
+			Use:   "vmr",
 			Short: "version manager",
 			Long:  "vmr <Command> <SubCommand> --flags args...",
 		},


### PR DESCRIPTION
这个可以先合并，目前没有在 Command 中指定二进制文件名，导致生成的所有的补全都是有问题的