### PR TITLE
fix install-self adding PATH repeatedly

### DIFF
--- a/internal/shell/sh/zsh.go
+++ b/internal/shell/sh/zsh.go
@@ -29,8 +29,7 @@ if [ -z "$(alias|grep cdhook)" ]; then
 fi
 # cd hook end
 
-export PATH=%s:$PATH
-`
+export PATH=%s:$PATH`
 
 /*
 internal/terminal/terminal.go line:90


### PR DESCRIPTION
修复了多次执行 `vmr i` 时，`zsh/bash` 中 `~/.vmr/vmr.sh` 内容重复的问题