### PR TITLE
fix(linux arm64): install script error

### DIFF
--- a/scripts/install.preview.sh
+++ b/scripts/install.preview.sh
@@ -67,7 +67,7 @@ main() {
 
     local osArch="amd64"
 
-    if  [ "$os_arch" = "arm64" ] || [ "$os_type" = "aarch64" ]; then
+    if  [ "$os_arch" = "arm64" ] || [ "$os_arch" = "aarch64" ]; then
         osArch="arm64"
     fi
     local url="https://packages.vmr.us.kg/$osType/$osArch"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -54,7 +54,7 @@ main() {
 
     local osArch="amd64"
 
-    if  [ "$os_arch" = "arm64" ] || [ "$os_type" = "aarch64" ]; then
+    if  [ "$os_arch" = "arm64" ] || [ "$os_arch" = "aarch64" ]; then
         osArch="arm64"
     fi
 


### PR DESCRIPTION
- 一键安装脚本下载了错误的amd64格式文件