### PR TITLE
export env: SHELL in install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -41,6 +41,7 @@ need_cmd() {
 }
 
 main() {
+    export SHELL=$SHELL
     local os_type="$(uname -s)"
     local os_arch="$(uname -m)"
 


### PR DESCRIPTION
通过在install.sh中增加export SHELL=$SHELL，解决internal/shell/unix.go:20, shellPath := os.Getenv("SHELL")为空的问题
https://github.com/gvcgo/version-manager/issues/127