### PR TITLE
Fix the issue where the VMR_VERSIONS variable cannot be referenced in the PATH on Windows.

### DIFF
--- a/internal/shell/win.go
+++ b/internal/shell/win.go
@@ -179,8 +179,7 @@ func (s *Shell) SetEnv(key, value string) {
 	if key == PathEnvName {
 		return
 	}
-	// err := s.Key.SetStringValue(key, value)
-	err := s.Key.SetExpandStringValue(key, value)
+	err := s.Key.SetStringValue(key, value)
 	if err != nil {
 		gprint.PrintError("Set env '%s=%s' failed: %+v", key, value, err)
 		return


### PR DESCRIPTION
fix [… the PATH on Windows.](https://github.com/gvcgo/version-manager/issues/182)


环境变量为扩展字符串，在path中被引用时，无法解析，导致path设置失效。